### PR TITLE
Add ContainerNode#lives_on

### DIFF
--- a/docs/ContainerNode.md
+++ b/docs/ContainerNode.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **name** | **String** |  | [optional] 
 **cpus** | **Integer** |  | [optional] 
 **memory** | **Integer** |  | [optional] 
+**lives_on** | [**InventoryObjectLazy**](InventoryObjectLazy.md) |  | [optional] 
 **source_created_at** | **DateTime** |  | [optional] 
 **source_deleted_at** | **DateTime** |  | [optional] 
 **resource_timestamp** | **DateTime** |  | [optional] 

--- a/lib/topological_inventory/ingress_api/client/models/container_node.rb
+++ b/lib/topological_inventory/ingress_api/client/models/container_node.rb
@@ -25,6 +25,8 @@ module TopologicalInventory::IngressApi::Client
 
     attr_accessor :memory
 
+    attr_accessor :lives_on
+
     attr_accessor :source_created_at
 
     attr_accessor :source_deleted_at
@@ -40,6 +42,7 @@ module TopologicalInventory::IngressApi::Client
         :'name' => :'name',
         :'cpus' => :'cpus',
         :'memory' => :'memory',
+        :'lives_on' => :'lives_on',
         :'source_created_at' => :'source_created_at',
         :'source_deleted_at' => :'source_deleted_at',
         :'resource_timestamp' => :'resource_timestamp'
@@ -54,6 +57,7 @@ module TopologicalInventory::IngressApi::Client
         :'name' => :'String',
         :'cpus' => :'Integer',
         :'memory' => :'Integer',
+        :'lives_on' => :'InventoryObjectLazy',
         :'source_created_at' => :'DateTime',
         :'source_deleted_at' => :'DateTime',
         :'resource_timestamp' => :'DateTime'
@@ -86,6 +90,10 @@ module TopologicalInventory::IngressApi::Client
 
       if attributes.has_key?(:'memory')
         self.memory = attributes[:'memory']
+      end
+
+      if attributes.has_key?(:'lives_on')
+        self.lives_on = attributes[:'lives_on']
       end
 
       if attributes.has_key?(:'source_created_at')
@@ -130,6 +138,7 @@ module TopologicalInventory::IngressApi::Client
           name == o.name &&
           cpus == o.cpus &&
           memory == o.memory &&
+          lives_on == o.lives_on &&
           source_created_at == o.source_created_at &&
           source_deleted_at == o.source_deleted_at &&
           resource_timestamp == o.resource_timestamp
@@ -144,7 +153,7 @@ module TopologicalInventory::IngressApi::Client
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [source_ref, resource_version, name, cpus, memory, source_created_at, source_deleted_at, resource_timestamp].hash
+      [source_ref, resource_version, name, cpus, memory, lives_on, source_created_at, source_deleted_at, resource_timestamp].hash
     end
 
     # Builds the object from hash

--- a/spec/models/container_node_spec.rb
+++ b/spec/models/container_node_spec.rb
@@ -62,6 +62,12 @@ describe 'ContainerNode' do
     end
   end
 
+  describe 'test attribute "lives_on"' do
+    it 'should work' do
+       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "source_created_at"' do
     it 'should work' do
        # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers


### PR DESCRIPTION
https://github.com/ManageIQ/topological_inventory-core/pull/57 Added a `ContainerNode#lives_on` polymorpic association, this allows collectors to set the cross-link

Depends on: https://github.com/ManageIQ/topological_inventory-ingress_api/pull/10