### PR TITLE
ServiceOffering:extra and ServicePlan:resource_timestamp

### DIFF
--- a/docs/ServiceOffering.md
+++ b/docs/ServiceOffering.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **long_description** | **String** |  | [optional] 
 **distributor** | **String** |  | [optional] 
 **support_url** | **String** |  | [optional] 
+**extra** | [**Object**](.md) |  | [optional] 
 **source_created_at** | **DateTime** |  | [optional] 
 **source_deleted_at** | **DateTime** |  | [optional] 
 **resource_timestamp** | **DateTime** |  | [optional] 

--- a/docs/ServicePlan.md
+++ b/docs/ServicePlan.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **resource_version** | **String** |  | [optional] 
 **source_created_at** | **DateTime** |  | [optional] 
 **source_deleted_at** | **DateTime** |  | [optional] 
+**resource_timestamp** | **DateTime** |  | [optional] 
 **create_json_schema** | [**Object**](.md) |  | [optional] 
 **update_json_schema** | [**Object**](.md) |  | [optional] 
 **service_offering** | [**InventoryObjectLazy**](InventoryObjectLazy.md) |  | [optional] 

--- a/lib/topological_inventory-ingress_api-client/models/service_offering.rb
+++ b/lib/topological_inventory-ingress_api-client/models/service_offering.rb
@@ -30,6 +30,8 @@ module TopologicalInventoryIngressApiClient
 
     attr_accessor :support_url
 
+    attr_accessor :extra
+
     attr_accessor :source_created_at
 
     attr_accessor :source_deleted_at
@@ -53,6 +55,7 @@ module TopologicalInventoryIngressApiClient
         :'long_description' => :'long_description',
         :'distributor' => :'distributor',
         :'support_url' => :'support_url',
+        :'extra' => :'extra',
         :'source_created_at' => :'source_created_at',
         :'source_deleted_at' => :'source_deleted_at',
         :'resource_timestamp' => :'resource_timestamp',
@@ -73,6 +76,7 @@ module TopologicalInventoryIngressApiClient
         :'long_description' => :'String',
         :'distributor' => :'String',
         :'support_url' => :'String',
+        :'extra' => :'Object',
         :'source_created_at' => :'DateTime',
         :'source_deleted_at' => :'DateTime',
         :'resource_timestamp' => :'DateTime',
@@ -120,6 +124,10 @@ module TopologicalInventoryIngressApiClient
 
       if attributes.has_key?(:'support_url')
         self.support_url = attributes[:'support_url']
+      end
+
+      if attributes.has_key?(:'extra')
+        self.extra = attributes[:'extra']
       end
 
       if attributes.has_key?(:'source_created_at')
@@ -178,6 +186,7 @@ module TopologicalInventoryIngressApiClient
           long_description == o.long_description &&
           distributor == o.distributor &&
           support_url == o.support_url &&
+          extra == o.extra &&
           source_created_at == o.source_created_at &&
           source_deleted_at == o.source_deleted_at &&
           resource_timestamp == o.resource_timestamp &&
@@ -195,7 +204,7 @@ module TopologicalInventoryIngressApiClient
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [source_ref, name, description, display_name, documentation_url, long_description, distributor, support_url, source_created_at, source_deleted_at, resource_timestamp, source_region, subscription, service_offering_icon].hash
+      [source_ref, name, description, display_name, documentation_url, long_description, distributor, support_url, extra, source_created_at, source_deleted_at, resource_timestamp, source_region, subscription, service_offering_icon].hash
     end
 
     # Builds the object from hash

--- a/lib/topological_inventory-ingress_api-client/models/service_plan.rb
+++ b/lib/topological_inventory-ingress_api-client/models/service_plan.rb
@@ -26,6 +26,8 @@ module TopologicalInventoryIngressApiClient
 
     attr_accessor :source_deleted_at
 
+    attr_accessor :resource_timestamp
+
     attr_accessor :create_json_schema
 
     attr_accessor :update_json_schema
@@ -45,6 +47,7 @@ module TopologicalInventoryIngressApiClient
         :'resource_version' => :'resource_version',
         :'source_created_at' => :'source_created_at',
         :'source_deleted_at' => :'source_deleted_at',
+        :'resource_timestamp' => :'resource_timestamp',
         :'create_json_schema' => :'create_json_schema',
         :'update_json_schema' => :'update_json_schema',
         :'service_offering' => :'service_offering',
@@ -62,6 +65,7 @@ module TopologicalInventoryIngressApiClient
         :'resource_version' => :'String',
         :'source_created_at' => :'DateTime',
         :'source_deleted_at' => :'DateTime',
+        :'resource_timestamp' => :'DateTime',
         :'create_json_schema' => :'Object',
         :'update_json_schema' => :'Object',
         :'service_offering' => :'InventoryObjectLazy',
@@ -100,6 +104,10 @@ module TopologicalInventoryIngressApiClient
 
       if attributes.has_key?(:'source_deleted_at')
         self.source_deleted_at = attributes[:'source_deleted_at']
+      end
+
+      if attributes.has_key?(:'resource_timestamp')
+        self.resource_timestamp = attributes[:'resource_timestamp']
       end
 
       if attributes.has_key?(:'create_json_schema')
@@ -152,6 +160,7 @@ module TopologicalInventoryIngressApiClient
           resource_version == o.resource_version &&
           source_created_at == o.source_created_at &&
           source_deleted_at == o.source_deleted_at &&
+          resource_timestamp == o.resource_timestamp &&
           create_json_schema == o.create_json_schema &&
           update_json_schema == o.update_json_schema &&
           service_offering == o.service_offering &&
@@ -168,7 +177,7 @@ module TopologicalInventoryIngressApiClient
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [source_ref, name, description, resource_version, source_created_at, source_deleted_at, create_json_schema, update_json_schema, service_offering, source_region, subscription].hash
+      [source_ref, name, description, resource_version, source_created_at, source_deleted_at, resource_timestamp, create_json_schema, update_json_schema, service_offering, source_region, subscription].hash
     end
 
     # Builds the object from hash


### PR DESCRIPTION
needed for AnsibleTower collector
`ServiceOffering:extra` can store type of job_template/workflow_job_template
`ServicePlan:resource_timestamp` was missing in yaml

related: https://github.com/ManageIQ/topological_inventory-ingress_api/pull/31