### PR TITLE
Prototype payload chunking

### DIFF
--- a/lib/topological_inventory-ingress_api-client/save_inventory/exception.rb
+++ b/lib/topological_inventory-ingress_api-client/save_inventory/exception.rb
@@ -1,0 +1,7 @@
+module TopologicalInventoryIngressApiClient
+  module SaveInventory
+    class Exception
+      class Error < StandardError; end
+    end
+  end
+end

--- a/lib/topological_inventory-ingress_api-client/save_inventory/exception.rb
+++ b/lib/topological_inventory-ingress_api-client/save_inventory/exception.rb
@@ -2,6 +2,7 @@ module TopologicalInventoryIngressApiClient
   module SaveInventory
     class Exception
       class Error < StandardError; end
+      class EntityTooLarge < Error; end
     end
   end
 end

--- a/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
+++ b/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
@@ -34,10 +34,10 @@ module TopologicalInventoryIngressApiClient
 
       def save_payload_in_batches(inventory)
         parts         = 0
-        new_inventory = new_inventory(inventory)
+        new_inventory = build_new_inventory(inventory)
 
         inventory[:collections].each do |collection|
-          new_collection = new_collection(collection)
+          new_collection = build_new_collection(collection)
 
           data = collection[:data].map { |x| JSON.generate(x) }
           # Lets compute sizes of the each data item, plus 1 byte for comma
@@ -68,8 +68,8 @@ module TopologicalInventoryIngressApiClient
               parts += 1
 
               # Create new data containers for a new batch
-              new_inventory  = new_inventory(inventory)
-              new_collection = new_collection(collection)
+              new_inventory  = build_new_inventory(inventory)
+              new_collection = build_new_collection(collection)
 
               # Start with the data part we've removed from the currently saved payload
               total_size = wrapper_size + data_size
@@ -99,11 +99,11 @@ module TopologicalInventoryIngressApiClient
         client.save_inventory_with_http_info(:inventory => inventory)
       end
 
-      def new_collection(collection)
+      def build_new_collection(collection)
         {:name => collection[:name], :data => []}
       end
 
-      def new_inventory(inventory)
+      def build_new_inventory(inventory)
         new_inventory                           = inventory.clone
         new_inventory[:refresh_state_part_uuid] = SecureRandom.uuid
         new_inventory[:collections]             = []

--- a/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
+++ b/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
@@ -52,6 +52,7 @@ module TopologicalInventoryIngressApiClient
             total_size += data_size
 
             if total_size > max_bytes
+              # Remove the last data part, that caused going over the max limit
               counter -= 1
 
               # Add the entities to new collection, so the total size is below max

--- a/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
+++ b/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
@@ -62,6 +62,7 @@ module TopologicalInventoryIngressApiClient
 
               # Save the current batch
               save_inventory(JSON.generate(new_inventory))
+              parts += 1
 
               # Create new data containers for a new batch
               new_inventory  = new_inventory(inventory)
@@ -79,6 +80,7 @@ module TopologicalInventoryIngressApiClient
 
         # Save the rest
         save_inventory(JSON.generate(new_inventory))
+        parts += 1
 
         return parts
       end

--- a/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
+++ b/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
@@ -73,6 +73,7 @@ module TopologicalInventoryIngressApiClient
               # Create new data containers for a new batch
               new_inventory  = build_new_inventory(inventory)
               new_collection = build_new_collection(collection)
+              wrapper_size = JSON.generate(new_inventory).size + JSON.generate(new_collection).size + 2
 
               # Start with the data part we've removed from the currently saved payload
               total_size = wrapper_size + data_size

--- a/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
+++ b/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
@@ -32,6 +32,8 @@ module TopologicalInventoryIngressApiClient
         end
       end
 
+      private
+
       def save_payload_in_batches(inventory)
         parts         = 0
         new_inventory = build_new_inventory(inventory)

--- a/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
+++ b/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
@@ -21,7 +21,7 @@ module TopologicalInventoryIngressApiClient
       def save(data)
         inventory = data[:inventory].to_hash
 
-        inventory_json = inventory.to_json
+        inventory_json = JSON.generate(inventory)
         if inventory_json.size < max_bytes
           save_inventory(inventory_json)
           return 1
@@ -39,12 +39,12 @@ module TopologicalInventoryIngressApiClient
         inventory[:collections].each do |collection|
           new_collection = new_collection(collection)
 
-          data = collection[:data].map(&:to_json)
+          data = collection[:data].map { |x| JSON.generate(x) }
           # Lets compute sizes of the each data item, plus 1 byte for comma
           data_sizes = data.map { |x| x.size + 1 }
 
           # Size of the current inventory and new_collection wrapper, plus 2 bytes for array signs
-          wrapper_size = new_inventory.to_json.size + new_collection.to_json.size + 2
+          wrapper_size = JSON.generate(new_inventory).size + JSON.generate(new_collection).size + 2
           total_size   = wrapper_size
           counter      = 0
           data_sizes.each do |data_size|
@@ -61,7 +61,7 @@ module TopologicalInventoryIngressApiClient
               new_inventory[:collections] << new_collection
 
               # Save the current batch
-              save_inventory(new_inventory.to_json)
+              save_inventory(JSON.generate(new_inventory))
 
               # Create new data containers for a new batch
               new_inventory  = new_inventory(inventory)
@@ -78,7 +78,7 @@ module TopologicalInventoryIngressApiClient
         end
 
         # Save the rest
-        save_inventory(new_inventory.to_json)
+        save_inventory(JSON.generate(new_inventory))
 
         return parts
       end

--- a/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
+++ b/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
@@ -3,10 +3,16 @@ require "topological_inventory-ingress_api-client/save_inventory/exception"
 module TopologicalInventoryIngressApiClient
   module SaveInventory
     class Saver
+      # As defined in:
+      # https://github.com/zendesk/ruby-kafka/blob/02f7e2816e1130c5202764c275e36837f57ca4af/lib/kafka/protocol/message.rb#L11-L17
+      # There is at least 112 bytes that are added as a message header, so we need to keep room for that. Lets make
+      # it 200 bytes, just for sure.
+      KAFKA_RESERVED_HEADER_SIZE = 200
+
       def initialize(client:, logger:, max_bytes: 1_000_000)
         @client    = client
         @logger    = logger
-        @max_bytes = 1_000_000
+        @max_bytes = max_bytes - KAFKA_RESERVED_HEADER_SIZE
       end
 
       attr_reader :client, :logger, :max_bytes

--- a/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
+++ b/lib/topological_inventory-ingress_api-client/save_inventory/saver.rb
@@ -85,7 +85,7 @@ module TopologicalInventoryIngressApiClient
         last_payload = JSON.generate(new_inventory)
         if (last_payload.size) > max_bytes
           raise TopologicalInventoryIngressApiClient::EntityTooLarge::SaveInventory::Exception::EntityTooLarge,
-                "Entity is bigger than total limit and can't be split: #{JSON.generate(new_inventory)}"
+                "Entity is bigger than total limit and can't be split: #{last_payload}"
         end
 
         # Save the rest


### PR DESCRIPTION
We need to make sure we only sent payload chunks of max allowed size. Right now the size limit in in kafka topic, but we'll move it to ingress server.

Benchmark:

A simple benchmark on a json file of size 6.3 MB
```ruby
require 'json'
require 'benchmark'

file_content = File.read('benchmark_data.json')
data         = JSON.parse(file_content)

n = 1000

Benchmark.bm do |benchmark|
  benchmark.report("to_json.size") do
    n.times do
      data.to_json.size
    end
  end

  benchmark.report("to_json.size") do
    n.times do
      data["collections"].map { |x| x["data"].map(&:to_json) }
    end
  end
end
```

result:
```
       user     system      total        real
to_json.size 90.064975   0.013951  90.078926 ( 90.255740)
to_json.size 141.605634   0.011976 141.617610 (141.955916)
```

so it's about 90ms to call to_json on the 6MB hash. And 140ms to call to_json on individual entities (Inventory Objects). So it's like 300-400ms overhead.

But given this data is obtained by loading 500 entities from the API server, the total time should be lower comparing to overhead of loading only 50 at a time as before.