### PR TITLE
Require saver for collector

### DIFF
--- a/lib/topological_inventory-ingress_api-client/collector.rb
+++ b/lib/topological_inventory-ingress_api-client/collector.rb
@@ -4,6 +4,7 @@ require "topological_inventory-ingress_api-client"
 require "topological_inventory-ingress_api-client/collector/inventory_collection_storage"
 require "topological_inventory-ingress_api-client/collector/inventory_collection_wrapper"
 require "topological_inventory-ingress_api-client/collector/parser"
+require "topological_inventory-ingress_api-client/save_inventory/saver"
 
 module TopologicalInventoryIngressApiClient
   class Collector


### PR DESCRIPTION
Moving `save_inventory` and `sweep_inventory` needs move of require from collectors to this gem.