### PR TITLE
Fix inventory collection deserialization

### DIFF
--- a/lib/topological_inventory-ingress_api-client/models/inventory.rb
+++ b/lib/topological_inventory-ingress_api-client/models/inventory.rb
@@ -58,7 +58,7 @@ module TopologicalInventoryIngressApiClient
         :'refresh_state_part_uuid' => :'String',
         :'total_parts' => :'Integer',
         :'sweep_scope' => :'Object',
-        :'collections' => :'Array<Object>'
+        :'collections' => :'Array<InventoryCollection>'
       }
     end
 


### PR DESCRIPTION
The Additional inventory collection type validation breaks client
deserialization, this is a temporary fix to allow for proper
deserialization.