### PR TITLE
Remove gemspec from openapi generator

### DIFF
--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -24,3 +24,4 @@
 
 .gitignore
 
+topological_inventory-ingress_api-client.gemspec

--- a/topological_inventory-ingress_api-client.gemspec
+++ b/topological_inventory-ingress_api-client.gemspec
@@ -27,8 +27,9 @@ Gem::Specification.new do |s|
   s.license     = "Unlicense"
   s.required_ruby_version = ">= 1.9"
 
-  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
+  s.add_runtime_dependency 'config', '~> 1.7', '>= 1.7.2'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
+  s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
   s.add_development_dependency 'vcr', '~> 3.0', '>= 3.0.1'


### PR DESCRIPTION
Removed gemspec from openapi generator (ingress-api rake `client:generate` doesn't overwrite it)
Re-added config gem to gemspec.

TODO: In the near future move all non-generated code out of this gem